### PR TITLE
feat:exposed visibility value for the provider in the DA

### DIFF
--- a/cra-config.yaml
+++ b/cra-config.yaml
@@ -8,3 +8,4 @@ CRA_TARGETS:
       TF_VAR_resource_group_name: "terraform-ibm-cloudant"
       TF_VAR_instance_name: "mock"
       TF_VAR_environment_crn: "test-env-crn"
+      TF_VAR_provider_visibility: "public"

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -8,7 +8,7 @@ locals {
       ? local.validate_sm_region_msg
   : ""))
 
-  sm_guid   = var.existing_sm_instance_guid == null ? module.secrets_manager.secrets_manager_guid : var.existing_sm_instance_guid
+  sm_guid   = var.existing_sm_instance_guid == null ? module.secrets_manager[0].secrets_manager_guid : var.existing_sm_instance_guid
   sm_region = var.existing_sm_instance_region == null ? var.region : var.existing_sm_instance_region
 }
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -78,6 +78,7 @@ resource "ibm_iam_access_group_members" "accgroupmem" {
 
 # Create Secrets Manager Instance
 module "secrets_manager" {
+  count                = var.existing_sm_instance_guid == null ? 1 : 0
   source               = "terraform-ibm-modules/secrets-manager/ibm"
   version              = "1.18.14"
   resource_group_id    = module.resource_group.resource_group_id

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -25,7 +25,7 @@ module "resource_group" {
 }
 
 ##############################################################################
-# Standard Cloudant Instance with IAM authentication
+# Standard Cloudant Instance with IAM Authentication
 ##############################################################################
 
 module "create_cloudant" {

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -92,7 +92,26 @@
                 "description": "This architecture supports creating and configuring an IBM Cloudant instance and database in an existing IBM Dedicated environment."
               }
             ]
+          },
+          "configuration":[
+            {
+            "key": "provider_visibility",
+            "options": [
+              {
+                "displayname": "private",
+                "value": "private"
+              },
+              {
+                "displayname": "public",
+                "value": "public"
+              },
+              {
+                "displayname": "public-and-private",
+                "value": "public-and-private"
+              }
+            ]
           }
+        ]
         }
       ]
     }

--- a/solutions/dedicated/provider.tf
+++ b/solutions/dedicated/provider.tf
@@ -2,4 +2,5 @@ provider "ibm" {
   ibmcloud_api_key = var.ibmcloud_api_key
   region           = var.region
   ibmcloud_timeout = 60
+  visibility       = var.provider_visibility
 }

--- a/solutions/dedicated/variables.tf
+++ b/solutions/dedicated/variables.tf
@@ -83,3 +83,13 @@ variable "database_config" {
   description = "The databases to create in the IBM Cloudant instance with options to create partitions and shards."
   default     = []
 }
+variable "provider_visibility" {
+  description = "Set the visibility value for the IBM terraform provider. Supported values are `public`, `private`, `public-and-private`. [Learn more](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/guides/custom-service-endpoints)."
+  type        = string
+  default     = "private"
+
+  validation {
+    condition     = contains(["public", "private", "public-and-private"], var.provider_visibility)
+    error_message = "Invalid visibility option. Allowed values are 'public', 'private', or 'public-and-private'."
+  }
+}

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -78,6 +78,7 @@ func TestRunDedicatedSolution(t *testing.T) {
 		// crn of the dedicated host
 		"environment_crn":         permanentResources["dedicatedHostCrn"],
 		"existing_resource_group": true,
+		"provider_visibility":     "public",
 		"resource_group_name":     options.ResourceGroup,
 		"instance_name":           options.Prefix,
 		"database_config": []map[string]interface{}{


### PR DESCRIPTION
### Description

exposed [visibility](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs#visibility) value for the provider in the DA , with default value set to "private"

[Git issue](https://github.ibm.com/GoldenEye/issues/issues/11322)
### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

exposes visibility value for the provider in the DA

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
